### PR TITLE
remove startTransaction(), endTransaction()

### DIFF
--- a/lib/Base/AdminBaseModel.php
+++ b/lib/Base/AdminBaseModel.php
@@ -47,26 +47,6 @@ class AdminBaseModel
 	}
 
 	/**
-	 * 트랜잭션 시작(모델이 아닌 서비스에서 명시적인 트랜잭션이 필요할 경우 사용)
-	 * @deprecated use transactional
-	 */
-	public static function startTransaction()
-	{
-		$db = self::getDb();
-		$db->sqlBegin();
-	}
-
-	/**
-	 * 트랜잭션 종료(모델이 아닌 서비스에서 명시적인 트랜잭션이 필요할 경우 사용)
-	 * @deprecated use transactional
-	 */
-	public static function endTransaction()
-	{
-		$db = self::getDb();
-		return $db->sqlEnd();
-	}
-
-	/**
 	 * 트랜잭셔널 (모델이 아닌 서비스에서 명시적인 트랜잭션이 필요할 경우 사용)
 	 * @param $func callable
 	 * @return bool

--- a/lib/Base/AdminBaseService.php
+++ b/lib/Base/AdminBaseService.php
@@ -2,32 +2,10 @@
 
 namespace Ridibooks\Platform\Common\Base;
 
-use Ridibooks\Library\DB\ConnectionProvider;
-use Ridibooks\Library\DB\GnfConnectionProvider;
 use Ridibooks\Platform\Common\PagingUtil;
 
 class AdminBaseService
 {
-	/**
-	 * 트랜잭션 시작
-	 * @deprecated AdminBaseModel로 옮길것
-	 */
-	protected function startTransaction()
-	{
-		$db = GnfConnectionProvider::getConnection(ConnectionProvider::CONNECTION_GROUP_PLATFORM_WRITE);
-		$db->sqlBegin();
-	}
-
-	/**
-	 * 트랜잭션 종료
-	 * @deprecated AdminBaseModel로 옮길것
-	 */
-	protected function endTransaction()
-	{
-		$db = GnfConnectionProvider::getConnection(ConnectionProvider::CONNECTION_GROUP_PLATFORM_WRITE);
-		$db->sqlEnd();
-	}
-
 	/**
 	 * 페이징 처리 html 태그를 만들어서 반환한다.
 	 * javascript는 fn_search로 통일시켰다.


### PR DESCRIPTION
sqlBegin()-sqlEnd()를 사용하고 있는 모든 부분을 수정하였습니다.
(유사 사용: AdminBaseModel::xxxTransaction(), AdminBaseService::xxxTransaction())

이에 따라서, 해당 메소드를 더이상 사용하지 않기위하여 제거 하고자합니다.