### PR TITLE
update composer.json: ridibooks/platform-gnfdb:  ^0.1.11-> ^0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### CHANGED
+- Change composer dependency: platform-gnfdb(^0.1.11 -> ^0.1.12) for using sqlInsertOrUpdateBulk
+
 ## [0.2.1] - 2018-08-07
 ### Added
 - Merge `DateUtils` Between `ridibooks/php-src` and `ridibooks\cp` on Only Using.
+- Move `FileUtils::escapeStringForAttachment` from `platform/admin`
+
 ### Removed
 - Remove deprecated Class from `DateUtil`.
-
-## [Unreleased]
-### Added
-- Move `FileUtils::escapeStringForAttachment` from `platform/admin`
 
 ## [0.2.0] - 2018-02-13
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "Ridibooks Platform's Common PHP Library",
   "license": "MIT",
   "require": {
-    "ridibooks/platform-gnfdb": "^0.1.11"
+    "ridibooks/platform-gnfdb": "^0.1.12"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
platform-gnfdb의 sqlInsertOrUpdateBulk를 사용하기 위해서

platform-common의 composer 의존성 올렸습니다.

검토 요청드립니다. 

검토해주시면 기능 추가라 v0.3.0으로 배포 예정입니다.