### PR TITLE
add xxx_slave to platform_connection_group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.1] - 2018-10-16
 ### ADDED
 - add PLATFORM_SLAVE to PlatformConnectionGroup
 - add PLATFORM_ONLY_DB_SLAVE to PlatformConnectionGroup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### ADDED
+- add PLATFORM_SLAVE to PlatformConnectionGroup
+- add PLATFORM_ONLY_DB_SLAVE to PlatformConnectionGroup
+- add PLATFORM_BOOK_DB_SLAVE to PlatformConnectionGroup
+- add CP_STATISTICS_SLAVE to PlatformConnectionGroup
+
 ## [0.3.0] - 2018-09-17
 ### CHANGED
 - Change composer dependency: platform-gnfdb(^0.1.11 -> ^0.1.12) for using sqlInsertOrUpdateBulk

--- a/lib/Constant/PlatformConnectionGroup.php
+++ b/lib/Constant/PlatformConnectionGroup.php
@@ -5,12 +5,20 @@ abstract class PlatformConnectionGroup
 {
     const PLATFORM_WRITE = 'bom_platform_write';
     const PLATFORM_READ = 'bom_platform_read';
+    const PLATFORM_SLAVE = 'bom_platform_slave';
+
     const PLATFORM_ONLY_DB_WRITE = 'platform_only_write';
     const PLATFORM_ONLY_DB_READ = 'platform_only_read';
+    const PLATFORM_ONLY_DB_SLAVE = 'platform_only_slave';
+
     const PLATFORM_BOOK_DB_WRITE = 'platform_book_write';
     const PLATFORM_BOOK_DB_READ = 'platform_book_read';
+    const PLATFORM_BOOK_DB_SLAVE = 'platform_book_slave';
+
     const CP_STATISTICS = 'cp_statistics';
     const CP_STATISTICS_READ = 'cp_statistics_read';
+    const CP_STATISTICS_SLAVE = 'cp_statistics_slave';
+
     const COMMON_MODULE_READ_MASTER = 'common_module_read_master';
     const COMMON_MODULE_READ = 'common_module_read';
 }

--- a/lib/PlatformBaseModel.php
+++ b/lib/PlatformBaseModel.php
@@ -42,6 +42,14 @@ abstract class PlatformBaseModel
     /**
      * @return static
      */
+    public static function createSlave()
+    {
+        return self::create(GnfConnectionProvider::getConnection(PlatformConnectionGroup::PLATFORM_SLAVE));
+    }
+
+    /**
+     * @return static
+     */
     public static function createPlatformOnlyWrite()
     {
         return self::create(GnfConnectionProvider::getConnection(PlatformConnectionGroup::PLATFORM_ONLY_DB_WRITE));
@@ -53,6 +61,14 @@ abstract class PlatformBaseModel
     public static function createPlatformOnlyRead()
     {
         return self::create(GnfConnectionProvider::getConnection(PlatformConnectionGroup::PLATFORM_ONLY_DB_READ));
+    }
+
+    /**
+     * @return static
+     */
+    public static function createPlatformOnlySlave()
+    {
+        return self::create(GnfConnectionProvider::getConnection(PlatformConnectionGroup::PLATFORM_ONLY_DB_SLAVE));
     }
 
     /**
@@ -74,6 +90,14 @@ abstract class PlatformBaseModel
     /**
      * @return static
      */
+    public static function createPlatformBookSlave()
+    {
+        return self::create(GnfConnectionProvider::getConnection(PlatformConnectionGroup::PLATFORM_BOOK_DB_SLAVE));
+    }
+
+    /**
+     * @return static
+     */
     public static function createCpstatWrite()
     {
         return self::create(GnfConnectionProvider::getConnection(PlatformConnectionGroup::CP_STATISTICS));
@@ -85,6 +109,14 @@ abstract class PlatformBaseModel
     public static function createCpstatRead()
     {
         return self::create(GnfConnectionProvider::getConnection(PlatformConnectionGroup::CP_STATISTICS_READ));
+    }
+
+    /**
+     * @return static
+     */
+    public static function createCpstatSlave()
+    {
+        return self::create(GnfConnectionProvider::getConnection(PlatformConnectionGroup::CP_STATISTICS_SLAVE));
     }
 
     public function transactional(callable $callable)


### PR DESCRIPTION
부하 분산을 위해서 명확하게 slave를 바라보도록 하는 connection_group 추가했습니다.

버전은 v3.1.0으로 배포 예정입니다.

참고로 AdminBaseModel은 앞으로 사용하지 않기 때문에, 그쪽에는 추가하지 않았습니다.

검토 요청드립니다.