### PR TITLE
Add FileLockUtils (from platform/download-service)

### DIFF
--- a/lib/FileLockUtils.php
+++ b/lib/FileLockUtils.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\Platform\Common;
+
+class FileLockUtils
+{
+    private const READ_TIMEOUT_RESOLUTION_MS = 250;
+    private const WRITE_TIMEOUT_RESOLUTION_MS = 100;
+    private const DEFAULT_LOCK_TIMEOUT = 60;
+
+    protected $lock_file_name;
+    protected $lock_dir;
+    protected $lock_file;
+
+    public function __construct(string $lock_file_name, string $lock_dir)
+    {
+        $this->lock_file_name = $lock_file_name;
+        $this->lock_dir = $lock_dir;
+    }
+
+    public function tryReadLock()
+    {
+        return $this->tryByType(false);
+    }
+
+    public function tryWriteLock()
+    {
+        return $this->tryByType(true);
+    }
+
+    private function tryByType(bool $is_exclusive): bool
+    {
+        if (!is_dir($this->lock_dir)) {
+            mkdir($this->lock_dir, 0666, true);
+        }
+
+        $this->lock_file = fopen($this->lock_file_name, 'w+');
+        @chmod($this->lock_file_name, 0666);
+        if ($this->lock_file === false) {
+            throw new \RuntimeException('Failed to open lock file');
+        }
+
+        $timeout_resolution = $is_exclusive ? self::WRITE_TIMEOUT_RESOLUTION_MS : self::READ_TIMEOUT_RESOLUTION_MS;
+        $elapsed_ms = 0;
+        $lock_flag = $is_exclusive ? LOCK_EX : LOCK_SH;
+        while (!flock($this->lock_file, $lock_flag | LOCK_NB, $is_blocked)) {
+            $elapsed_ms += $timeout_resolution;
+            if ($is_blocked && $elapsed_ms <= (self::DEFAULT_LOCK_TIMEOUT * 1000)) {
+                usleep($timeout_resolution * 1000);
+            } else {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+
+    public function releaseLock()
+    {
+        flock($this->lock_file, LOCK_UN);
+        @fclose($this->lock_file);
+    }
+}


### PR DESCRIPTION
기존 download-service에 구현되어있던 file lock 관련 코드 부분을 분리하였습니다.

- download-service 외 플랫폼 프로젝트에서 이용하기 위함
- ridibooks/core의 fileLock 사용을 위해 core 전체를 참조하기에는 오버스펙으로 판단