### PR TITLE
Sentry 기본 설정 스택 트레이스 활성화

### DIFF
--- a/lib/Sentry/Clients/LumenSentryClient.php
+++ b/lib/Sentry/Clients/LumenSentryClient.php
@@ -17,10 +17,14 @@ class LumenSentryClient implements SentryClientInterface
     private static function updateConfig(string $sentry_key, array $options, int $error_types): void
     {
         $option_namespace = ServiceProvider::$abstract;
-        $default_options = ['dsn' => $sentry_key, 'error_types' => $error_types];
+        $options = array_merge(
+            self::DEFAULT_OPTIONS,
+            ['dsn' => $sentry_key, 'error_types' => $error_types],
+            $options
+        );
 
         $configs = [];
-        foreach (array_merge($default_options, $options) as $key => $value) {
+        foreach ($options as $key => $value) {
             $configs["{$option_namespace}.{$key}"] = $value;
         }
         config($configs);

--- a/lib/Sentry/Clients/SentryClient.php
+++ b/lib/Sentry/Clients/SentryClient.php
@@ -15,7 +15,11 @@ class SentryClient implements SentryClientInterface
 
     private static function registerRavenClient(string $sentry_key, array $options, int $error_types): void
     {
-        $default_options = ['dsn' => $sentry_key, 'error_types' => $error_types];
-        init(array_merge($default_options, $options));
+        $options = array_merge(
+            self::DEFAULT_OPTIONS,
+            ['dsn' => $sentry_key, 'error_types' => $error_types],
+            $options
+        );
+        init($options);
     }
 }

--- a/lib/Sentry/SentryClientInterface.php
+++ b/lib/Sentry/SentryClientInterface.php
@@ -5,8 +5,9 @@ namespace Ridibooks\Platform\Common\Sentry;
 
 interface SentryClientInterface
 {
+    // TODO: enableSentry, overrideSentry 제거 완료 후 protected로 변경
     public const DEFAULT_ERROR_TYPES = E_ALL & ~E_NOTICE & ~E_STRICT;
-    public const DEFAULT_OPTIONS = ['attach_stacktrace' => true];
+    protected const DEFAULT_OPTIONS = ['attach_stacktrace' => true];
 
     public static function init($sentry_key, $options = [], $error_types = self::DEFAULT_ERROR_TYPES);
 }

--- a/lib/Sentry/SentryClientInterface.php
+++ b/lib/Sentry/SentryClientInterface.php
@@ -6,6 +6,7 @@ namespace Ridibooks\Platform\Common\Sentry;
 interface SentryClientInterface
 {
     public const DEFAULT_ERROR_TYPES = E_ALL & ~E_NOTICE & ~E_STRICT;
+    public const DEFAULT_OPTIONS = ['attach_stacktrace' => true];
 
     public static function init($sentry_key, $options = [], $error_types = self::DEFAULT_ERROR_TYPES);
 }


### PR DESCRIPTION
Sentry PHP SDK 2.0에서 기본값 false로 변경된 스택 트레이스 전송 기능을 true로 지정합니다.