### PR TITLE
kafka message dto 사용하도록 수정

### DIFF
--- a/lib/Kafka/Dto/KafkaMessageDto.php
+++ b/lib/Kafka/Dto/KafkaMessageDto.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\Platform\Common\Kafka\Dto;
+
+class KafkaMessageDto
+{
+    /** @var string  */
+    public $topic_name;
+    /** @var string|null  */
+    public $key;
+    /** @var string|null  */
+    public $value;
+    /** @var string[]|null  */
+    public $headers;
+
+    /**
+     * @param string $topic_name
+     * @param string|null $value
+     * @param string|null $key
+     * @param string[]|null $headers
+     * @return self
+     */
+    public static function import(string $topic_name, ?string $value, ?string $key, ?array $headers): self {
+        $dto = new self();
+        $dto->topic_name = $topic_name;
+        $dto->value = $value;
+        $dto->key = $key;
+        $dto->headers = $headers;
+
+        return $dto;
+    }
+}


### PR DESCRIPTION
CloudEvents 폼을 기반으로 메시지 보내도록 코드를 전체적으로 수정해보았습니다.

https://gitlab.com/ridicorp/platform/php-src/-/merge_requests/64
참고 바랍니다.


https://github.com/ridi/ridi/blob/master/backends/src/r-bus/publishNotifyBookImageCache.ts
https://github.com/ridi/ridi/blob/master/backends/src/apps/misc-origin/handler.ts
위 monorepo 의 기존 처리 코드를 참조했습니다.